### PR TITLE
Rename example, update Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bevy_fmod"
 description = "Idiomatic FMOD in Bevy"
 authors = ["Fabian 'Salzian' Fritzsche <bevy_fmod@salzian.dev>"]
+edition = "2021"
 repository = "https://github.com/salzian/bevy_fmod"
 version = "0.2.0"
 license = "MIT OR Apache-2.0"
@@ -17,4 +18,4 @@ libfmod = "2.2.607"
 bevy = "0.11.2"
 
 [[example]]
-name = "hello_world"
+name = "minimal"

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,6 +1,3 @@
-extern crate bevy;
-extern crate bevy_fmod;
-
 use bevy::prelude::EventWriter;
 use bevy::DefaultPlugins;
 use bevy::{app::App, prelude::Startup};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,3 @@
-extern crate anyhow;
-extern crate bevy;
-extern crate bevy_mod_sysfail;
-extern crate libfmod;
-
 mod play_sound_event;
 mod plugin;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,10 +1,10 @@
+use crate::PlaySoundEvent;
 use bevy::app::{App, Plugin};
 use bevy::log::{debug, trace};
 use bevy::prelude::{EventReader, NonSend, PostUpdate, Resource, Startup, Update, World};
 use bevy_mod_sysfail::sysfail;
 use libfmod::ffi::{FMOD_INIT_NORMAL, FMOD_STUDIO_INIT_NORMAL, FMOD_STUDIO_LOAD_BANK_NORMAL};
 use libfmod::{EventDescription, Studio};
-use play_sound_event::PlaySoundEvent;
 use std::env::var;
 use std::fs::{canonicalize, read_dir};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Rename example to make the intent more clear, upcoming examples will have more functionality but it's good to have an example that is as simple as possible.

Edition update makes it so we can get rid of `extern crate` everywhere.