### PR TITLE
Update libfmod to thread-safe variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ license = "MIT OR Apache-2.0"
 anyhow = "1.0.75"
 bevy = { version = "0.11.2", default-features = false }
 bevy_mod_sysfail = "3.0.0"
-libfmod = "2.2.607"
+libfmod = "2.206.2"
 
 [dev-dependencies]
-# The hello_world example needs the default features of bevy
-bevy = "0.11.2"
+bevy = { version = "0.11.2", default-features = true }
 
 [[example]]
 name = "minimal"


### PR DESCRIPTION
libfmod now implements `Sync` for relevant types, as the FMOD API is thread-safe and references / pointers can be passed around.