### PR TITLE
Use FMOD Studio Examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+assets/
 *.lib
 *.dll
 demo_project/

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ bevy_fmod = { git = "https://github.com/Salzian/bevy_fmod.git", tag = "v0.1.0" }
 
 ## Examples
 
-This repository includes a `hello_world` example. In order to run it, you need
-to [download the demo project][demo_project] (Google Drive link) and place it into the root of the
-project: `./demo_project`.
+FMOD Studio comes with an Examples project. Open it and build the project. Then put the bank files inside the assets folder of this repository.
+You can also configure FMOD Studio to build to a folder you specify.
+Run examples with `cargo run --example`. See the source code of the examples for more details.
 
 ## Versioning
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -15,8 +15,9 @@ fn main() {
             DefaultPlugins,
             FmodPlugin {
                 audio_banks_paths: &[
-                    "./demo_project/Build/Desktop/Master.bank",
-                    "./demo_project/Build/Desktop/Master.strings.bank",
+                    "./assets/Master.bank",
+                    "./assets/Master.strings.bank",
+                    "./assets/Music.bank",
                 ],
             },
         ))
@@ -29,7 +30,7 @@ fn main() {
 struct MyMusicPlayer;
 
 fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
-    let event_description = studio.0.get_event("event:/Return").unwrap();
+    let event_description = studio.0.get_event("event:/Music/Level 03").unwrap();
 
     commands
         .spawn(MyMusicPlayer)

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -33,8 +33,9 @@ fn main() {
             DefaultPlugins,
             FmodPlugin {
                 audio_banks_paths: &[
-                    "./demo_project/Build/Desktop/Master.bank",
-                    "./demo_project/Build/Desktop/Master.strings.bank",
+                    "./assets/Master.bank",
+                    "./assets/Master.strings.bank",
+                    "./assets/Music.bank",
                 ],
             },
         ))
@@ -52,7 +53,7 @@ fn spawn_sound(
     studio: Res<FmodStudio>,
     input: Res<Input<KeyCode>>,
 ) {
-    let event_description = studio.0.get_event("event:/Return").unwrap();
+    let event_description = studio.0.get_event("event:/Music/Radio Station").unwrap();
 
     if input.just_pressed(KeyCode::F) {
         commands.spawn((


### PR DESCRIPTION
Closes #27.

Make use of the Examples project that comes with FMOD Studio.
Updated Readme to reflect this.

I went with the `assets` folder because that is currently idiomatic for Bevy projects.
Together with the instructions in Readme it will not matter anymore where the Examples project is located. As long as the banks end up in the assets folder.