### PR TITLE
Split spatial example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ live-update = []
 name = "minimal"
 
 [[example]]
+name = "audio_control"
+
+[[example]]
 name = "spatial"
 
 [[example]]

--- a/examples/audio_control.rs
+++ b/examples/audio_control.rs
@@ -1,0 +1,63 @@
+//! Audio control:
+//! `AudioSource` implements `AudioSinkPlayback` from Bevy, so you can control the audio as normal.
+//!
+//! Controls:
+//! Press S, P and T to stop, play and toggle the sounds, respectively.
+//! See `AudioSinkPlayback` documentation for more functions.
+
+use bevy::prelude::*;
+use bevy_fmod::prelude::AudioSource;
+use bevy_fmod::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            FmodPlugin {
+                audio_banks_paths: &[
+                    "./assets/audio/demo_project/Build/Desktop/Master.bank",
+                    "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
+                    "./assets/audio/demo_project/Build/Desktop/Music.bank",
+                ],
+            },
+        ))
+        .add_systems(Startup, startup)
+        .add_systems(PostStartup, play_music)
+        .add_systems(Update, audio_control)
+        .run();
+}
+
+#[derive(Component)]
+struct MyMusicPlayer;
+
+fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
+    let event_description = studio.0.get_event("event:/Music/Level 03").unwrap();
+
+    commands
+        .spawn(MyMusicPlayer)
+        .insert(AudioSource::new(event_description));
+}
+
+fn play_music(mut audio_sources: Query<&AudioSource, With<MyMusicPlayer>>) {
+    audio_sources.single_mut().play();
+}
+
+fn audio_control(query: Query<&AudioSource>, input: Res<Input<KeyCode>>) {
+    if input.just_pressed(KeyCode::S) {
+        for audio_player in query.iter() {
+            audio_player.stop();
+        }
+    }
+
+    if input.just_pressed(KeyCode::P) {
+        for audio_player in query.iter() {
+            audio_player.play();
+        }
+    }
+
+    if input.just_pressed(KeyCode::T) {
+        for audio_player in query.iter() {
+            audio_player.toggle();
+        }
+    }
+}

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -2,12 +2,10 @@
 //! Having a TransformBundle on the FmodAudioSource
 //! and a FmodListener on the camera (for example) is enough to get the spatial audio working.
 //!
-//! Make sure your chosen sound has a spatializer effect on it.
+//! Make sure your chosen sound has a spatializer assigned to it in FMOD Studio.
 //!
 //! Controls:
 //! Use WASD, Space, Shift and the mouse to move around.
-//! Press F to spawn an audio source.
-//! Press O, P and T to stop, play and toggle the sounds, respectively.
 
 use bevy::prelude::*;
 use bevy_fmod::prelude::AudioSource;
@@ -32,59 +30,17 @@ fn main() {
         .add_plugins(LookTransformPlugin)
         .add_plugins(FpsCameraPlugin::default())
         .add_systems(Startup, setup_scene)
-        .add_systems(Update, (spawn_sound, audio_control))
+        .add_systems(PostStartup, play_music)
         .run();
-}
-
-fn spawn_sound(
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-    studio: Res<FmodStudio>,
-    input: Res<Input<KeyCode>>,
-) {
-    let event_description = studio.0.get_event("event:/Music/Radio Station").unwrap();
-
-    if input.just_pressed(KeyCode::F) {
-        commands.spawn((
-            AudioSource::new(event_description),
-            Velocity::default(),
-            PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-                material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-                transform: Transform::from_xyz(-1.0, 0.0, 1.0).with_scale(Vec3::splat(0.2)),
-                ..default()
-            },
-        ));
-    }
-}
-
-fn audio_control(query: Query<&AudioSource>, input: Res<Input<KeyCode>>) {
-    if input.just_pressed(KeyCode::O) {
-        for audio_player in query.iter() {
-            audio_player.stop();
-        }
-    }
-
-    if input.just_pressed(KeyCode::P) {
-        for audio_player in query.iter() {
-            audio_player.play();
-        }
-    }
-
-    if input.just_pressed(KeyCode::T) {
-        for audio_player in query.iter() {
-            audio_player.toggle();
-        }
-    }
 }
 
 fn setup_scene(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    studio: Res<FmodStudio>,
 ) {
-    // plane
+    // Plane
     commands.spawn(PbrBundle {
         mesh: meshes.add(shape::Plane::from_size(5.0).into()),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
@@ -100,7 +56,7 @@ fn setup_scene(
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
-    // camera
+    // Camera
     commands
         .spawn(Camera3dBundle::default())
         .insert((AudioListener::default(), Velocity::default()))
@@ -110,4 +66,21 @@ fn setup_scene(
             Vec3::new(0., 0., 0.),
             Vec3::Y,
         ));
+    // Audio source
+    let event_description = studio.0.get_event("event:/Music/Radio Station").unwrap();
+
+    commands.spawn((
+        AudioSource::new(event_description),
+        Velocity::default(),
+        PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            transform: Transform::from_xyz(-1.0, 0.0, 1.0).with_scale(Vec3::splat(0.2)),
+            ..default()
+        },
+    ));
+}
+
+fn play_music(mut audio_sources: Query<&AudioSource>) {
+    audio_sources.single_mut().play();
 }


### PR DESCRIPTION
Adds new audio_control example to make it easier to digest the spatial example.
Starts the audio immediately in the spatial example to avoid confusion.
Closes #36 