### PR TITLE
Make Velocity optional

### DIFF
--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -2,7 +2,8 @@
 //! Having a TransformBundle on the FmodAudioSource
 //! and a FmodListener on the camera (for example) is enough to get the spatial audio working.
 //!
-//! Make sure your chosen sound has a spatializer effect on it.
+//! Make sure your chosen sound has a spatializer effect on it, using FMOD Studio.
+//! The Velocity components are only needed if you want to enable the Doppler effect.
 //!
 //! Controls:
 //! Use WASD, Space, Shift and the mouse to move around.

--- a/src/components/audio_listener.rs
+++ b/src/components/audio_listener.rs
@@ -13,11 +13,11 @@ impl AudioListener {
         query: Query<(&GlobalTransform, Option<&Velocity>), With<AudioListener>>,
         studio: Res<FmodStudio>,
     ) {
-        if let Ok((transform, velocity)) = query.get_single() {
-            let mut velo = Vec3::ZERO;
+        if let Ok((transform, vel_component)) = query.get_single() {
+            let mut velocity = Vec3::ZERO;
 
-            if let Some(vel) = velocity {
-                velo = vel.current_velocity;
+            if let Some(vel_component) = vel_component {
+                velocity = vel_component.current_velocity;
             }
 
             studio
@@ -26,7 +26,7 @@ impl AudioListener {
                     0,
                     attributes3d(
                         transform.translation(),
-                        velo,
+                        velocity,
                         transform.forward(),
                         transform.up(),
                     ),

--- a/src/components/audio_listener.rs
+++ b/src/components/audio_listener.rs
@@ -1,3 +1,4 @@
+use bevy::math::Vec3;
 use bevy::prelude::{Component, GlobalTransform, Query, Res, With};
 
 use crate::attributes_3d::attributes3d;
@@ -9,18 +10,24 @@ pub struct AudioListener;
 
 impl AudioListener {
     pub(crate) fn update_3d_attributes(
-        query: Query<(&Velocity, &GlobalTransform), With<AudioListener>>,
+        query: Query<(&GlobalTransform, Option<&Velocity>), With<AudioListener>>,
         studio: Res<FmodStudio>,
     ) {
         match query.get_single() {
-            Ok((velocity, transform)) => {
+            Ok((transform, velocity)) => {
+                let mut velo = Vec3::ZERO;
+
+                if let Some(vel) = velocity {
+                    velo = vel.current_velocity;
+                }
+
                 studio
                     .0
                     .set_listener_attributes(
                         0,
                         attributes3d(
                             transform.translation(),
-                            velocity.current_velocity,
+                            velo,
                             transform.forward(),
                             transform.up(),
                         ),

--- a/src/components/audio_listener.rs
+++ b/src/components/audio_listener.rs
@@ -13,29 +13,26 @@ impl AudioListener {
         query: Query<(&GlobalTransform, Option<&Velocity>), With<AudioListener>>,
         studio: Res<FmodStudio>,
     ) {
-        match query.get_single() {
-            Ok((transform, velocity)) => {
-                let mut velo = Vec3::ZERO;
+        if let Ok((transform, velocity)) = query.get_single() {
+            let mut velo = Vec3::ZERO;
 
-                if let Some(vel) = velocity {
-                    velo = vel.current_velocity;
-                }
-
-                studio
-                    .0
-                    .set_listener_attributes(
-                        0,
-                        attributes3d(
-                            transform.translation(),
-                            velo,
-                            transform.forward(),
-                            transform.up(),
-                        ),
-                        None,
-                    )
-                    .unwrap();
+            if let Some(vel) = velocity {
+                velo = vel.current_velocity;
             }
-            _ => {}
+
+            studio
+                .0
+                .set_listener_attributes(
+                    0,
+                    attributes3d(
+                        transform.translation(),
+                        velo,
+                        transform.forward(),
+                        transform.up(),
+                    ),
+                    None,
+                )
+                .unwrap();
         }
     }
 }

--- a/src/components/audio_listener.rs
+++ b/src/components/audio_listener.rs
@@ -5,6 +5,7 @@ use crate::attributes_3d::attributes3d;
 use crate::components::velocity::Velocity;
 use crate::fmod_studio::FmodStudio;
 
+/// See the [`Velocity`] component for information on enabling the Doppler effect.
 #[derive(Component, Default)]
 pub struct AudioListener;
 

--- a/src/components/audio_source.rs
+++ b/src/components/audio_source.rs
@@ -23,18 +23,18 @@ impl AudioSource {
     ) {
         query
             .iter_mut()
-            .for_each(|(audio_source, transform, velocity)| {
-                let mut velo = Vec3::ZERO;
+            .for_each(|(audio_source, transform, vel_component)| {
+                let mut velocity = Vec3::ZERO;
 
-                if let Some(vel) = velocity {
-                    velo = vel.current_velocity;
+                if let Some(vel_component) = vel_component {
+                    velocity = vel_component.current_velocity;
                 }
 
                 audio_source
                     .event_instance
                     .set_3d_attributes(attributes3d(
                         transform.translation(),
-                        velo,
+                        velocity,
                         transform.forward(),
                         transform.up(),
                     ))

--- a/src/components/audio_source.rs
+++ b/src/components/audio_source.rs
@@ -6,6 +6,7 @@ use libfmod::{EventDescription, EventInstance, StopMode};
 use crate::attributes_3d::attributes3d;
 use crate::components::velocity::Velocity;
 
+/// See the [`Velocity`] component for information on enabling the Doppler effect.
 #[derive(Component)]
 pub struct AudioSource {
     pub event_instance: EventInstance,

--- a/src/components/audio_source.rs
+++ b/src/components/audio_source.rs
@@ -1,3 +1,4 @@
+use bevy::math::Vec3;
 use bevy::prelude::{AudioSinkPlayback, Component, GlobalTransform, Query};
 use libfmod::StopMode::Immediate;
 use libfmod::{EventDescription, EventInstance, StopMode};
@@ -18,16 +19,22 @@ impl AudioSource {
     }
 
     pub(crate) fn update_3d_attributes(
-        mut query: Query<(&AudioSource, &Velocity, &GlobalTransform)>,
+        mut query: Query<(&AudioSource, &GlobalTransform, Option<&Velocity>)>,
     ) {
         query
             .iter_mut()
-            .for_each(|(audio_source, velocity, transform)| {
+            .for_each(|(audio_source, transform, velocity)| {
+                let mut velo = Vec3::ZERO;
+
+                if let Some(vel) = velocity {
+                    velo = vel.current_velocity;
+                }
+
                 audio_source
                     .event_instance
                     .set_3d_attributes(attributes3d(
                         transform.translation(),
-                        velocity.current_velocity,
+                        velo,
                         transform.forward(),
                         transform.up(),
                     ))

--- a/src/components/bundles.rs
+++ b/src/components/bundles.rs
@@ -19,19 +19,9 @@ impl SpatialAudioBundle {
     }
 }
 
-#[derive(Bundle)]
+#[derive(Bundle, Default)]
 pub struct SpatialListenerBundle {
     audio_listener: AudioListener,
     velocity: Velocity,
     transform: Transform,
-}
-
-impl Default for SpatialListenerBundle {
-    fn default() -> Self {
-        SpatialListenerBundle {
-            audio_listener: AudioListener::default(),
-            velocity: Velocity::default(),
-            transform: Transform::default(),
-        }
-    }
 }

--- a/src/components/velocity.rs
+++ b/src/components/velocity.rs
@@ -5,7 +5,8 @@ use bevy::prelude::{Component, FixedTime, GlobalTransform, Query, Res};
 /// Automatic velocity updates for [`AudioListener`] and [`AudioSource`]
 ///
 /// Make sure to add this component to your listener and source entities in order
-/// to enable the Doppler effect.
+/// to enable the Doppler effect. The recommended way to do this is to use the [`SpatialAudioBundle`]
+/// and [`SpatialListenerBundle`].
 #[derive(Component, Default)]
 pub struct Velocity {
     last_position: Vec3,

--- a/src/components/velocity.rs
+++ b/src/components/velocity.rs
@@ -2,6 +2,10 @@ use bevy::app::{App, Plugin, Update};
 use bevy::math::Vec3;
 use bevy::prelude::{Component, FixedTime, GlobalTransform, Query, Res};
 
+/// Automatic velocity updates for [`AudioListener`] and [`AudioSource`]
+///
+/// Make sure to add this component to your listener and source entities in order
+/// to enable the Doppler effect.
 #[derive(Component, Default)]
 pub struct Velocity {
     last_position: Vec3,


### PR DESCRIPTION
Just found out there is a bug where if you don't have the Velocity component the spatial audio doesn't work at all. This will fix that.