### PR TITLE
Better specification of versions in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.75"
-bevy = { version = "0.11.2", default-features = false, features = ["bevy_audio"] }
+bevy = { version = "0.11", default-features = false, features = ["bevy_audio"] }
 bevy_mod_sysfail = "3.0.0"
-libfmod = "2.206.2"
+libfmod = "~2.206.2"
 
 [dev-dependencies]
 # The examples need the default features of bevy
-bevy = { version = "0.11.2", default-features = true }
+bevy = { version = "0.11", default-features = true }
 smooth-bevy-cameras = "0.9.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ version = "0.3.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-anyhow = "1.0.75"
+  anyhow = "1.0"
 bevy = { version = "0.11", default-features = false, features = ["bevy_audio"] }
-bevy_mod_sysfail = "3.0.0"
+bevy_mod_sysfail = "3.0"
 libfmod = "~2.206.2"
 
 [dev-dependencies]
 # The examples need the default features of bevy
 bevy = { version = "0.11", default-features = true }
-smooth-bevy-cameras = "0.9.0"
+smooth-bevy-cameras = "0.9"
 
 [features]
 default = []


### PR DESCRIPTION
Stumbled over [this](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio) and thought some dependency notations could be improved.