### PR TITLE
Provide bundles for spatial audio

### DIFF
--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -11,6 +11,7 @@
 
 use bevy::prelude::*;
 use bevy_fmod::prelude::AudioSource;
+use bevy_fmod::prelude::SpatialAudioBundle;
 use bevy_fmod::prelude::*;
 use smooth_bevy_cameras::{
     controllers::fps::{FpsCameraBundle, FpsCameraController, FpsCameraPlugin},
@@ -47,8 +48,7 @@ fn spawn_sound(
 
     if input.just_pressed(KeyCode::F) {
         commands.spawn((
-            AudioSource::new(event_description),
-            Velocity::default(),
+            SpatialAudioBundle::new(event_description),
             PbrBundle {
                 mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
                 material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
@@ -103,7 +103,7 @@ fn setup_scene(
     // camera
     commands
         .spawn(Camera3dBundle::default())
-        .insert((AudioListener::default(), Velocity::default()))
+        .insert(SpatialListenerBundle::default())
         .insert(FpsCameraBundle::new(
             FpsCameraController::default(),
             Vec3::new(-2.0, 5.0, 5.0),

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -47,15 +47,14 @@ fn spawn_sound(
     let event_description = studio.0.get_event("event:/Music/Radio Station").unwrap();
 
     if input.just_pressed(KeyCode::F) {
-        commands.spawn((
-            SpatialAudioBundle::new(event_description),
-            PbrBundle {
+        commands
+            .spawn(SpatialAudioBundle::new(event_description))
+            .insert(PbrBundle {
                 mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
                 material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
                 transform: Transform::from_xyz(-1.0, 0.0, 1.0).with_scale(Vec3::splat(0.2)),
                 ..default()
-            },
-        ));
+            });
     }
 }
 

--- a/src/components/bundles.rs
+++ b/src/components/bundles.rs
@@ -1,0 +1,37 @@
+use crate::prelude::{AudioListener, AudioSource, Velocity};
+use bevy::prelude::{Bundle, Transform};
+use libfmod::EventDescription;
+
+#[derive(Bundle)]
+pub struct SpatialAudioBundle {
+    audio_source: AudioSource,
+    velocity: Velocity,
+    transform: Transform,
+}
+
+impl SpatialAudioBundle {
+    pub fn new(event_description: EventDescription) -> Self {
+        SpatialAudioBundle {
+            audio_source: AudioSource::new(event_description),
+            velocity: Velocity::default(),
+            transform: Transform::default(),
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub struct SpatialListenerBundle {
+    audio_listener: AudioListener,
+    velocity: Velocity,
+    transform: Transform,
+}
+
+impl Default for SpatialListenerBundle {
+    fn default() -> Self {
+        SpatialListenerBundle {
+            audio_listener: AudioListener::default(),
+            velocity: Velocity::default(),
+            transform: Transform::default(),
+        }
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,3 +1,37 @@
+use crate::prelude::{AudioListener, AudioSource, Velocity};
+use bevy::prelude::Bundle;
+use libfmod::EventDescription;
+
 pub mod audio_listener;
 pub mod audio_source;
 pub mod velocity;
+
+#[derive(Bundle)]
+pub struct SpatialAudioBundle {
+    audio_source: AudioSource,
+    velocity: Velocity,
+}
+
+impl SpatialAudioBundle {
+    pub fn new(event_description: EventDescription) -> Self {
+        SpatialAudioBundle {
+            audio_source: AudioSource::new(event_description),
+            velocity: Velocity::default(),
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub struct SpatialListenerBundle {
+    audio_listener: AudioListener,
+    velocity: Velocity,
+}
+
+impl Default for SpatialListenerBundle {
+    fn default() -> Self {
+        SpatialListenerBundle {
+            audio_listener: AudioListener::default(),
+            velocity: Velocity::default(),
+        }
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,41 +1,4 @@
-use crate::prelude::{AudioListener, AudioSource, Velocity};
-use bevy::prelude::{Bundle, Transform};
-use libfmod::EventDescription;
-
 pub mod audio_listener;
 pub mod audio_source;
+pub mod bundles;
 pub mod velocity;
-
-#[derive(Bundle)]
-pub struct SpatialAudioBundle {
-    audio_source: AudioSource,
-    velocity: Velocity,
-    transform: Transform,
-}
-
-impl SpatialAudioBundle {
-    pub fn new(event_description: EventDescription) -> Self {
-        SpatialAudioBundle {
-            audio_source: AudioSource::new(event_description),
-            velocity: Velocity::default(),
-            transform: Transform::default(),
-        }
-    }
-}
-
-#[derive(Bundle)]
-pub struct SpatialListenerBundle {
-    audio_listener: AudioListener,
-    velocity: Velocity,
-    transform: Transform,
-}
-
-impl Default for SpatialListenerBundle {
-    fn default() -> Self {
-        SpatialListenerBundle {
-            audio_listener: AudioListener::default(),
-            velocity: Velocity::default(),
-            transform: Transform::default(),
-        }
-    }
-}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,5 +1,5 @@
 use crate::prelude::{AudioListener, AudioSource, Velocity};
-use bevy::prelude::Bundle;
+use bevy::prelude::{Bundle, Transform};
 use libfmod::EventDescription;
 
 pub mod audio_listener;
@@ -10,6 +10,7 @@ pub mod velocity;
 pub struct SpatialAudioBundle {
     audio_source: AudioSource,
     velocity: Velocity,
+    transform: Transform,
 }
 
 impl SpatialAudioBundle {
@@ -17,6 +18,7 @@ impl SpatialAudioBundle {
         SpatialAudioBundle {
             audio_source: AudioSource::new(event_description),
             velocity: Velocity::default(),
+            transform: Transform::default(),
         }
     }
 }
@@ -25,6 +27,7 @@ impl SpatialAudioBundle {
 pub struct SpatialListenerBundle {
     audio_listener: AudioListener,
     velocity: Velocity,
+    transform: Transform,
 }
 
 impl Default for SpatialListenerBundle {
@@ -32,6 +35,7 @@ impl Default for SpatialListenerBundle {
         SpatialListenerBundle {
             audio_listener: AudioListener::default(),
             velocity: Velocity::default(),
+            transform: Transform::default(),
         }
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,7 @@
 pub use crate::components::audio_listener::AudioListener;
 pub use crate::components::audio_source::AudioSource;
 pub use crate::components::velocity::Velocity;
+pub use crate::components::SpatialAudioBundle;
+pub use crate::components::SpatialListenerBundle;
 pub use crate::fmod_plugin::FmodPlugin;
 pub use crate::fmod_studio::FmodStudio;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
 pub use crate::components::audio_listener::AudioListener;
 pub use crate::components::audio_source::AudioSource;
+pub use crate::components::bundles::SpatialAudioBundle;
+pub use crate::components::bundles::SpatialListenerBundle;
 pub use crate::components::velocity::Velocity;
-pub use crate::components::SpatialAudioBundle;
-pub use crate::components::SpatialListenerBundle;
 pub use crate::fmod_plugin::FmodPlugin;
 pub use crate::fmod_studio::FmodStudio;


### PR DESCRIPTION
Addition/alternative to #53.
Slightly simplifies spatial example, makes it more difficult to accidentally forget the Velocity component.
But it's still possible to add the components as we did previously, without the Velocity if the user prefers that. But #53 would need to be solved first.