### PR TITLE
Remove smooth-bevy-cameras dependency from spatial example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ libfmod = "2.206.2"
 [dev-dependencies]
 # The examples need the default features of bevy
 bevy = { version = "0.11.2", default-features = true }
-smooth-bevy-cameras = "0.9.0"
 
 [features]
 default = []

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -43,6 +43,7 @@ fn setup_scene(
         transform: Transform::from_xyz(0.0, -1.0, 0.0),
         ..default()
     });
+
     // Light
     commands.spawn(PointLightBundle {
         point_light: PointLight {
@@ -53,13 +54,16 @@ fn setup_scene(
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
+
     // Camera
     commands
         .spawn(Camera3dBundle::default())
         .insert((AudioListener::default(), Velocity::default()));
-    // Audio source
+
+    // FMOD audio event
     let event_description = studio.0.get_event("event:/Music/Radio Station").unwrap();
 
+    // Audio source: Orbiting cube
     commands.spawn((
         AudioSource::new(event_description),
         Velocity::default(),

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -57,7 +57,10 @@ fn setup_scene(
 
     // Camera
     commands
-        .spawn(Camera3dBundle::default())
+        .spawn(Camera3dBundle {
+            transform: Transform::from_xyz(0.0, 0.0, 4.0),
+            ..default()
+        })
         .insert((AudioListener::default(), Velocity::default()));
 
     // FMOD audio event
@@ -85,8 +88,8 @@ fn orbit_audio_source(
     mut audio_sources: Query<&mut Transform, With<AudioSource>>,
 ) {
     for mut audio_source in audio_sources.iter_mut() {
-        audio_source.translation.x = time.elapsed_seconds().sin() * 3.0;
-        audio_source.translation.z = time.elapsed_seconds().cos() * 3.0;
+        audio_source.translation.x = time.elapsed_seconds().sin() * 2.0;
+        audio_source.translation.z = time.elapsed_seconds().cos() * 2.0;
     }
 }
 


### PR DESCRIPTION
This will make it easier to update bevy_fmod for new releases of Bevy.
Took some inspiration from the Bevy spatial example.
Feedback welcome!