### PR TITLE
Helper method to allow easier creation of AudioSources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ assets/
 *.so.*
 demo_project/
 Cargo.lock
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ assets/
 *.so.*
 demo_project/
 Cargo.lock
-.vscode/
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ assets/
 demo_project/
 Cargo.lock
 .vscode/
+.idea/

--- a/examples/audio_control.rs
+++ b/examples/audio_control.rs
@@ -31,11 +31,9 @@ fn main() {
 struct MyMusicPlayer;
 
 fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
-    let event_description = studio.0.get_event("event:/Music/Level 03").unwrap();
-
     commands
         .spawn(MyMusicPlayer)
-        .insert(AudioSource::new(event_description));
+        .insert(studio.build_audio_source("event:/Music/Level 03"));
 }
 
 fn play_music(mut audio_sources: Query<&AudioSource, With<MyMusicPlayer>>) {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -26,11 +26,9 @@ fn main() {
 struct MyMusicPlayer;
 
 fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
-    let event_description = studio.0.get_event("event:/Music/Level 03").unwrap();
-
     commands
         .spawn(MyMusicPlayer)
-        .insert(AudioSource::new(event_description));
+        .insert(studio.build_audio_source("event:/Music/Level 03"));
 }
 
 fn play_music(mut audio_sources: Query<&AudioSource, With<MyMusicPlayer>>) {

--- a/examples/parameters.rs
+++ b/examples/parameters.rs
@@ -63,17 +63,13 @@ struct ForestSfxPlayer;
 struct CountrySfxPlayer;
 
 fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
-    let event_description = studio.0.get_event("event:/Ambience/Forest").unwrap();
-
     commands
         .spawn(ForestSfxPlayer)
-        .insert(AudioSource::new(event_description));
-
-    let event_description = studio.0.get_event("event:/Ambience/Country").unwrap();
+        .insert(studio.build_audio_source("event:/Ambience/Forest"));
 
     commands
         .spawn(CountrySfxPlayer)
-        .insert(AudioSource::new(event_description));
+        .insert(studio.build_audio_source("event:/Ambience/Country"));
 }
 
 fn play_music(audio_sources: Query<&AudioSource>) {

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -66,10 +66,10 @@ fn setup_scene(
             Vec3::Y,
         ));
     // Audio source
-    let event_description = studio.0.get_event("event:/Music/Radio Station").unwrap();
-
     commands
-        .spawn(SpatialAudioBundle::new(event_description))
+        .spawn(SpatialAudioBundle::new(
+            studio.build_audio_source("event:/Music/Radio Station"),
+        ))
         .insert(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),

--- a/src/components/bundles.rs
+++ b/src/components/bundles.rs
@@ -1,6 +1,5 @@
 use crate::prelude::{AudioListener, AudioSource, Velocity};
 use bevy::prelude::{Bundle, Transform};
-use libfmod::EventDescription;
 
 #[derive(Bundle)]
 pub struct SpatialAudioBundle {
@@ -10,9 +9,9 @@ pub struct SpatialAudioBundle {
 }
 
 impl SpatialAudioBundle {
-    pub fn new(event_description: EventDescription) -> Self {
+    pub fn new(audio_source: AudioSource) -> Self {
         SpatialAudioBundle {
-            audio_source: AudioSource::new(event_description),
+            audio_source,
             velocity: Velocity::default(),
             transform: Transform::default(),
         }

--- a/src/fmod_studio.rs
+++ b/src/fmod_studio.rs
@@ -2,7 +2,7 @@ use std::env::var;
 use std::fs::canonicalize;
 use std::path::{Path, PathBuf};
 
-use crate::components::audio_source::AudioSource as BevyFmodAudioSource;
+use crate::components::audio_source::AudioSource;
 use bevy::prelude::{debug, trace, Resource};
 #[cfg(feature = "live-update")]
 use libfmod::ffi::FMOD_STUDIO_INIT_LIVEUPDATE;
@@ -68,11 +68,11 @@ impl FmodStudio {
         studio
     }
 
-    pub fn build_audio_source_from_path(&self, path: &str) -> BevyFmodAudioSource {
+    pub fn build_audio_source(&self, path_or_id: &str) -> AudioSource {
         let event_description = self
             .0
-            .get_event(path)
-            .expect("The event is expected to exist in the FMOD project.");
-        BevyFmodAudioSource::new(event_description)
+            .get_event(path_or_id)
+            .expect("Failed to get FMOD event from path or ID.");
+        AudioSource::new(event_description)
     }
 }

--- a/src/fmod_studio.rs
+++ b/src/fmod_studio.rs
@@ -2,14 +2,14 @@ use std::env::var;
 use std::fs::canonicalize;
 use std::path::{Path, PathBuf};
 
-use bevy::prelude::{debug, trace, Resource, AudioSource};
+use crate::components::audio_source::AudioSource as BevyFmodAudioSource;
+use bevy::prelude::{debug, trace, Resource};
 #[cfg(feature = "live-update")]
 use libfmod::ffi::FMOD_STUDIO_INIT_LIVEUPDATE;
 use libfmod::ffi::{
     FMOD_INIT_3D_RIGHTHANDED, FMOD_STUDIO_INIT_NORMAL, FMOD_STUDIO_LOAD_BANK_NORMAL,
 };
 use libfmod::Studio;
-use crate::components::audio_source::AudioSource as BevyFmodAudioSource;
 
 #[derive(Resource)]
 pub struct FmodStudio(pub Studio);
@@ -68,9 +68,11 @@ impl FmodStudio {
         studio
     }
 
-    pub fn build_audio_source_from_path(&self, path: &str) -> BevyFmodAudioSource{
-        let event_description = self.0.get_event(path).expect("The event is expected to exist in the FMOD project.");
+    pub fn build_audio_source_from_path(&self, path: &str) -> BevyFmodAudioSource {
+        let event_description = self
+            .0
+            .get_event(path)
+            .expect("The event is expected to exist in the FMOD project.");
         BevyFmodAudioSource::new(event_description)
     }
-
 }

--- a/src/fmod_studio.rs
+++ b/src/fmod_studio.rs
@@ -2,13 +2,14 @@ use std::env::var;
 use std::fs::canonicalize;
 use std::path::{Path, PathBuf};
 
-use bevy::prelude::{debug, trace, Resource};
+use bevy::prelude::{debug, trace, Resource, AudioSource};
 #[cfg(feature = "live-update")]
 use libfmod::ffi::FMOD_STUDIO_INIT_LIVEUPDATE;
 use libfmod::ffi::{
     FMOD_INIT_3D_RIGHTHANDED, FMOD_STUDIO_INIT_NORMAL, FMOD_STUDIO_LOAD_BANK_NORMAL,
 };
 use libfmod::Studio;
+use crate::components::audio_source::AudioSource as BevyFmodAudioSource;
 
 #[derive(Resource)]
 pub struct FmodStudio(pub Studio);
@@ -66,4 +67,10 @@ impl FmodStudio {
 
         studio
     }
+
+    pub fn build_audio_source_from_path(&self, path: &str) -> BevyFmodAudioSource{
+        let event_description = self.0.get_event(path).expect("The event is expected to exist in the FMOD project.");
+        BevyFmodAudioSource::new(event_description)
+    }
+
 }


### PR DESCRIPTION
With the current state of things, this is a simple way to spawn an AudioSource component:
```rust
fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
    let event_description = studio.0.get_event("event:/Music/Level 03").unwrap();

    commands
        .spawn(MyMusicPlayer)
        .insert(AudioSource::new(event_description));
}
```

With my proposed helper method, it would look more like this:
```rust
fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
    commands
        .spawn(MyMusicPlayer)
        .insert(studio.build_audio_source_from_path("event:/Music/Level 03"));
}
```

I have some questions, but I will leave them as inline comments for further discussion (I never tried doing that before so we shall see how it goes). 