### PR TITLE
Update to Bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,15 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
-bevy = { version = "0.12", default-features = false, features = ["bevy_audio"] }
+#bevy = { version = "0.12", default-features = false, features = ["bevy_audio"] }
+bevy = { git="https://github.com/bevyengine/bevy.git", branch = "main", default-features = false, features = ["bevy_audio"] }
 bevy_mod_sysfail = "3.0"
 libfmod = "~2.206.2"
 
 [dev-dependencies]
 # The examples need the default features of bevy
-bevy = { version = "0.12", default-features = true }
+#bevy = { version = "0.12", default-features = true }
+bevy = { git="https://github.com/bevyengine/bevy.git", branch = "main", default-features = true }
 
 [features]
 default = []

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -37,8 +37,8 @@ fn setup_scene(
 ) {
     // Plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(Plane3d::default().mesh().size(5.0, 5.0)),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         transform: Transform::from_xyz(0.0, -1.0, 0.0),
         ..default()
     });
@@ -68,8 +68,8 @@ fn setup_scene(
     commands
         .spawn(SpatialAudioBundle::new(event_description))
         .insert(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            mesh: meshes.add(Cuboid::default()),
+            material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
             transform: Transform::from_scale(Vec3::splat(0.2)),
             ..default()
         });
@@ -90,7 +90,7 @@ fn orbit_audio_source(
 }
 
 fn update_listener(
-    keyboard: Res<Input<KeyCode>>,
+    keyboard: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
     mut listeners: Query<&mut Transform, With<AudioListener>>,
 ) {
@@ -98,16 +98,16 @@ fn update_listener(
 
     let speed = 4.;
 
-    if keyboard.pressed(KeyCode::Right) {
+    if keyboard.pressed(KeyCode::ArrowRight) {
         transform.translation.x += speed * time.delta_seconds();
     }
-    if keyboard.pressed(KeyCode::Left) {
+    if keyboard.pressed(KeyCode::ArrowLeft) {
         transform.translation.x -= speed * time.delta_seconds();
     }
-    if keyboard.pressed(KeyCode::Down) {
+    if keyboard.pressed(KeyCode::ArrowDown) {
         transform.translation.z += speed * time.delta_seconds();
     }
-    if keyboard.pressed(KeyCode::Up) {
+    if keyboard.pressed(KeyCode::ArrowUp) {
         transform.translation.z -= speed * time.delta_seconds();
     }
 }


### PR DESCRIPTION
The relevant Bevy PR #'s are as following, although they only affect the examples.

Buttons: 10702, 10859, and potentially 11692.
Shapes: 11688.
Lights: 11347, and potentially 11581.

Seems like a trivial migration but sadly ran into the following error after making the changes:
```
LINK : fatal error LNK1181: cannot open input file 'fmod_vc.lib'
```
Afaik I haven't touched my setup since the 0.12 update. Only made the changes listed in this PR and I did `cargo update` and `rustup update`. Figured I'd still post here in case anyone else is interested.

Todo:

- [ ] Use 0.13 in cargo.toml
- [ ] Update Readme
- [ ] Check if the light in the spatial example needs adjusting