### PR TITLE
Add configurable stop mode

### DIFF
--- a/examples/audio_control.rs
+++ b/examples/audio_control.rs
@@ -35,7 +35,7 @@ fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
 
     commands
         .spawn(MyMusicPlayer)
-        .insert(AudioSource::new(event_description));
+        .insert(AudioSource::new(event_description, None));
 }
 
 fn play_music(mut audio_sources: Query<&AudioSource, With<MyMusicPlayer>>) {

--- a/examples/audio_control.rs
+++ b/examples/audio_control.rs
@@ -32,9 +32,10 @@ struct MyMusicPlayer;
 fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
     let event_description = studio.get_event("event:/Music/Level 03").unwrap();
 
-    commands
-        .spawn(MyMusicPlayer)
-        .insert(AudioSource::new(event_description, None));
+    commands.spawn(MyMusicPlayer).insert(AudioSource {
+        event_instance: event_description.create_instance().unwrap(),
+        despawn_stop_mode: StopMode::AllowFadeout,
+    });
 }
 
 fn play_music(mut audio_sources: Query<&AudioSource, With<MyMusicPlayer>>) {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -30,7 +30,7 @@ fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
 
     commands
         .spawn(MyMusicPlayer)
-        .insert(AudioSource::new(event_description));
+        .insert(AudioSource::new(event_description, None));
 }
 
 fn play_music(mut audio_sources: Query<&AudioSource, With<MyMusicPlayer>>) {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -4,6 +4,7 @@
 use bevy::prelude::*;
 use bevy_fmod::prelude::AudioSource;
 use bevy_fmod::prelude::*;
+use libfmod::StopMode;
 
 fn main() {
     App::new()
@@ -26,9 +27,10 @@ struct MyMusicPlayer;
 fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
     let event_description = studio.get_event("event:/Music/Level 03").unwrap();
 
-    commands
-        .spawn(MyMusicPlayer)
-        .insert(AudioSource::new(event_description, None));
+    commands.spawn(MyMusicPlayer).insert(AudioSource {
+        event_instance: event_description.create_instance().unwrap(),
+        despawn_stop_mode: StopMode::AllowFadeout,
+    });
 }
 
 fn play_music(mut audio_sources: Query<&AudioSource, With<MyMusicPlayer>>) {

--- a/examples/parameters.rs
+++ b/examples/parameters.rs
@@ -37,6 +37,7 @@
 use bevy::prelude::*;
 use bevy_fmod::prelude::AudioSource;
 use bevy_fmod::prelude::*;
+use libfmod::StopMode;
 
 fn main() {
     App::new()
@@ -63,15 +64,17 @@ struct CountrySfxPlayer;
 fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
     let event_description = studio.get_event("event:/Ambience/Forest").unwrap();
 
-    commands
-        .spawn(ForestSfxPlayer)
-        .insert(AudioSource::new(event_description, None));
+    commands.spawn(ForestSfxPlayer).insert(AudioSource {
+        event_instance: event_description.create_instance().unwrap(),
+        despawn_stop_mode: StopMode::AllowFadeout,
+    });
 
     let event_description = studio.get_event("event:/Ambience/Country").unwrap();
 
-    commands
-        .spawn(CountrySfxPlayer)
-        .insert(AudioSource::new(event_description, None));
+    commands.spawn(CountrySfxPlayer).insert(AudioSource {
+        event_instance: event_description.create_instance().unwrap(),
+        despawn_stop_mode: StopMode::AllowFadeout,
+    });
 }
 
 fn play_music(audio_sources: Query<&AudioSource>) {

--- a/examples/parameters.rs
+++ b/examples/parameters.rs
@@ -67,13 +67,13 @@ fn startup(mut commands: Commands, studio: Res<FmodStudio>) {
 
     commands
         .spawn(ForestSfxPlayer)
-        .insert(AudioSource::new(event_description));
+        .insert(AudioSource::new(event_description, None));
 
     let event_description = studio.0.get_event("event:/Ambience/Country").unwrap();
 
     commands
         .spawn(CountrySfxPlayer)
-        .insert(AudioSource::new(event_description));
+        .insert(AudioSource::new(event_description, None));
 }
 
 fn play_music(audio_sources: Query<&AudioSource>) {

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -62,11 +62,13 @@ fn setup_scene(
     // Audio source: Orbiting cube
     let event_description = studio.get_event("event:/Music/Radio Station").unwrap();
 
+    let audio_source = AudioSource {
+        event_instance: event_description.create_instance().unwrap(),
+        despawn_stop_mode: StopMode::AllowFadeout,
+    };
+
     commands
-        .spawn(SpatialAudioBundle::new(
-            event_description,
-            Some(StopMode::Immediate),
-        ))
+        .spawn(SpatialAudioBundle::from(audio_source))
         .insert(PbrBundle {
             mesh: meshes.add(Cuboid::default()),
             material: materials.add(Color::srgb(0.8, 0.7, 0.6)),

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -8,6 +8,7 @@
 use bevy::prelude::*;
 use bevy_fmod::prelude::AudioSource;
 use bevy_fmod::prelude::*;
+use libfmod::StopMode;
 
 fn main() {
     App::new()
@@ -64,7 +65,10 @@ fn setup_scene(
     let event_description = studio.0.get_event("event:/Music/Radio Station").unwrap();
 
     commands
-        .spawn(SpatialAudioBundle::new(event_description))
+        .spawn(SpatialAudioBundle::new(
+            event_description,
+            Some(StopMode::Immediate),
+        ))
         .insert(PbrBundle {
             mesh: meshes.add(Cuboid::default()),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6)),

--- a/src/components/bundles.rs
+++ b/src/components/bundles.rs
@@ -1,6 +1,6 @@
 use crate::prelude::{AudioListener, AudioSource, Velocity};
 use bevy::prelude::{Bundle, Transform};
-use libfmod::EventDescription;
+use libfmod::{EventDescription, StopMode};
 
 #[derive(Bundle)]
 pub struct SpatialAudioBundle {
@@ -10,9 +10,9 @@ pub struct SpatialAudioBundle {
 }
 
 impl SpatialAudioBundle {
-    pub fn new(event_description: EventDescription) -> Self {
+    pub fn new(event_description: EventDescription, stop_mode: Option<StopMode>) -> Self {
         SpatialAudioBundle {
-            audio_source: AudioSource::new(event_description),
+            audio_source: AudioSource::new(event_description, stop_mode),
             velocity: Velocity::default(),
             transform: Transform::default(),
         }

--- a/src/components/bundles.rs
+++ b/src/components/bundles.rs
@@ -10,9 +10,23 @@ pub struct SpatialAudioBundle {
 }
 
 impl SpatialAudioBundle {
-    pub fn new(event_description: EventDescription, stop_mode: Option<StopMode>) -> Self {
+    #[deprecated = "Use `AudioSource::from` instead."]
+    pub fn new(event_description: EventDescription) -> Self {
         SpatialAudioBundle {
-            audio_source: AudioSource::new(event_description, stop_mode),
+            audio_source: AudioSource {
+                event_instance: event_description.create_instance().unwrap(),
+                despawn_stop_mode: StopMode::AllowFadeout,
+            },
+            velocity: Velocity::default(),
+            transform: TransformBundle::default(),
+        }
+    }
+}
+
+impl From<AudioSource> for SpatialAudioBundle {
+    fn from(value: AudioSource) -> Self {
+        SpatialAudioBundle {
+            audio_source: value,
             velocity: Velocity::default(),
             transform: TransformBundle::default(),
         }

--- a/src/fmod_plugin.rs
+++ b/src/fmod_plugin.rs
@@ -1,4 +1,5 @@
-use bevy::prelude::{App, Plugin, PostUpdate, Res, Update};
+use bevy::app::PreStartup;
+use bevy::prelude::{App, Plugin, PostUpdate, Res, Update, World};
 use bevy_mod_sysfail::sysfail;
 
 use crate::components::audio_listener::AudioListener;
@@ -19,6 +20,7 @@ impl Plugin for FmodPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(VelocityPlugin)
             .insert_resource(FmodStudio::new(self.audio_banks_paths, self.plugin_paths))
+            .add_systems(PreStartup, register_component_hooks)
             .add_systems(
                 Update,
                 (
@@ -33,14 +35,28 @@ impl Plugin for FmodPlugin {
 impl FmodPlugin {
     #[sysfail(log(level = "error"))]
     fn update(studio: Res<FmodStudio>) -> anyhow::Result<()> {
-        studio.0.update()?;
+        studio.update()?;
         Ok(())
     }
 
+    #[must_use]
     pub fn new(audio_banks_paths: &'static [&'static str]) -> Self {
         FmodPlugin {
             audio_banks_paths,
             plugin_paths: None,
         }
     }
+}
+
+fn register_component_hooks(world: &mut World) {
+    world
+        .register_component_hooks::<AudioSource>()
+        .on_remove(|mut world, entity, _| {
+            let mut entity_mut = world.entity_mut(entity);
+            let audio_source = entity_mut.get_mut::<AudioSource>().unwrap();
+            let event_instance = audio_source.event_instance;
+
+            event_instance.stop(audio_source.despawn_stop_mode).unwrap();
+            event_instance.release().unwrap();
+        });
 }


### PR DESCRIPTION
Partial solution to #72 as it would now be possible to configure a new sound with stop_mode = None. Then you could despawn the entity immediately and the sound would play until the end.

Maybe a better solution would be to create a new enum instead of the `Option<StopMode>`.  That way we can give it a more appropriate name and avoid the necessity for users to import `libfmod::StopMode`. LMK