### PR TITLE
Make sure spatial audio bundles always have a GlobalTransform

### DIFF
--- a/src/components/bundles.rs
+++ b/src/components/bundles.rs
@@ -14,7 +14,7 @@ impl SpatialAudioBundle {
         SpatialAudioBundle {
             audio_source: AudioSource::new(event_description),
             velocity: Velocity::default(),
-            transform: TransformBundle::default()
+            transform: TransformBundle::default(),
         }
     }
 }

--- a/src/components/bundles.rs
+++ b/src/components/bundles.rs
@@ -1,12 +1,12 @@
 use crate::prelude::{AudioListener, AudioSource, Velocity};
-use bevy::prelude::{Bundle, Transform};
+use bevy::{prelude::Bundle, transform::TransformBundle};
 use libfmod::EventDescription;
 
 #[derive(Bundle)]
 pub struct SpatialAudioBundle {
     audio_source: AudioSource,
     velocity: Velocity,
-    transform: Transform,
+    transform: TransformBundle,
 }
 
 impl SpatialAudioBundle {
@@ -14,7 +14,7 @@ impl SpatialAudioBundle {
         SpatialAudioBundle {
             audio_source: AudioSource::new(event_description),
             velocity: Velocity::default(),
-            transform: Transform::default(),
+            transform: TransformBundle::default()
         }
     }
 }
@@ -23,5 +23,5 @@ impl SpatialAudioBundle {
 pub struct SpatialListenerBundle {
     audio_listener: AudioListener,
     velocity: Velocity,
-    transform: Transform,
+    transform: TransformBundle,
 }


### PR DESCRIPTION
Fixes #75 

was just missing the GlobalTransform component in the audio bundle causing the update query to not pass.