### PR TITLE
Support FMOD dynamic plugin loading

### DIFF
--- a/examples/audio_control.rs
+++ b/examples/audio_control.rs
@@ -13,13 +13,11 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin {
-                audio_banks_paths: &[
-                    "./assets/audio/demo_project/Build/Desktop/Master.bank",
-                    "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
-                    "./assets/audio/demo_project/Build/Desktop/Music.bank",
-                ],
-            },
+            FmodPlugin::from_audio_bank_paths(&[
+                "./assets/audio/demo_project/Build/Desktop/Master.bank",
+                "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
+                "./assets/audio/demo_project/Build/Desktop/Music.bank",
+            ]),
         ))
         .add_systems(Startup, startup)
         .add_systems(PostStartup, play_music)

--- a/examples/audio_control.rs
+++ b/examples/audio_control.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin::from_audio_banks(&[
+            FmodPlugin::new(&[
                 "./assets/audio/demo_project/Build/Desktop/Master.bank",
                 "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
                 "./assets/audio/demo_project/Build/Desktop/Music.bank",

--- a/examples/audio_control.rs
+++ b/examples/audio_control.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin::from_audio_bank_paths(&[
+            FmodPlugin::from_audio_banks(&[
                 "./assets/audio/demo_project/Build/Desktop/Master.bank",
                 "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
                 "./assets/audio/demo_project/Build/Desktop/Music.bank",

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -9,13 +9,11 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin {
-                audio_banks_paths: &[
-                    "./assets/audio/demo_project/Build/Desktop/Master.bank",
-                    "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
-                    "./assets/audio/demo_project/Build/Desktop/Music.bank",
-                ],
-            },
+            FmodPlugin::from_audio_bank_paths(&[
+                "./assets/audio/demo_project/Build/Desktop/Master.bank",
+                "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
+                "./assets/audio/demo_project/Build/Desktop/Music.bank",
+            ]),
         ))
         .add_systems(Startup, startup)
         .add_systems(PostStartup, play_music)

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -9,7 +9,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin::from_audio_bank_paths(&[
+            FmodPlugin::from_audio_banks(&[
                 "./assets/audio/demo_project/Build/Desktop/Master.bank",
                 "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
                 "./assets/audio/demo_project/Build/Desktop/Music.bank",

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -9,7 +9,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin::from_audio_banks(&[
+            FmodPlugin::new(&[
                 "./assets/audio/demo_project/Build/Desktop/Master.bank",
                 "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
                 "./assets/audio/demo_project/Build/Desktop/Music.bank",

--- a/examples/parameters.rs
+++ b/examples/parameters.rs
@@ -42,7 +42,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin::from_audio_banks(&[
+            FmodPlugin::new(&[
                 "./assets/audio/demo_project/Build/Desktop/Master.bank",
                 "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
                 "./assets/audio/demo_project/Build/Desktop/SFX.bank",

--- a/examples/parameters.rs
+++ b/examples/parameters.rs
@@ -42,7 +42,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin::from_audio_bank_paths(&[
+            FmodPlugin::from_audio_banks(&[
                 "./assets/audio/demo_project/Build/Desktop/Master.bank",
                 "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
                 "./assets/audio/demo_project/Build/Desktop/SFX.bank",

--- a/examples/parameters.rs
+++ b/examples/parameters.rs
@@ -42,13 +42,11 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin {
-                audio_banks_paths: &[
-                    "./assets/audio/demo_project/Build/Desktop/Master.bank",
-                    "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
-                    "./assets/audio/demo_project/Build/Desktop/SFX.bank",
-                ],
-            },
+            FmodPlugin::from_audio_bank_paths(&[
+                "./assets/audio/demo_project/Build/Desktop/Master.bank",
+                "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
+                "./assets/audio/demo_project/Build/Desktop/SFX.bank",
+            ]),
         ))
         .add_systems(Startup, startup)
         .add_systems(PostStartup, play_music)

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin::from_audio_banks(&[
+            FmodPlugin::new(&[
                 "./assets/audio/demo_project/Build/Desktop/Master.bank",
                 "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
                 "./assets/audio/demo_project/Build/Desktop/Music.bank",

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin::from_audio_bank_paths(&[
+            FmodPlugin::from_audio_banks(&[
                 "./assets/audio/demo_project/Build/Desktop/Master.bank",
                 "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
                 "./assets/audio/demo_project/Build/Desktop/Music.bank",

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -13,13 +13,11 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            FmodPlugin {
-                audio_banks_paths: &[
-                    "./assets/audio/demo_project/Build/Desktop/Master.bank",
-                    "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
-                    "./assets/audio/demo_project/Build/Desktop/Music.bank",
-                ],
-            },
+            FmodPlugin::from_audio_bank_paths(&[
+                "./assets/audio/demo_project/Build/Desktop/Master.bank",
+                "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
+                "./assets/audio/demo_project/Build/Desktop/Music.bank",
+            ]),
         ))
         .add_systems(Startup, setup_scene)
         .add_systems(PostStartup, play_music)

--- a/src/fmod_plugin.rs
+++ b/src/fmod_plugin.rs
@@ -33,7 +33,7 @@ impl FmodPlugin {
         Ok(())
     }
 
-    pub fn from_audio_bank_paths(paths: &'static [&'static str]) -> Self {
+    pub fn from_audio_banks(paths: &'static [&'static str]) -> Self {
         FmodPlugin {
             audio_banks_paths: paths,
             plugin_paths: &[],

--- a/src/fmod_plugin.rs
+++ b/src/fmod_plugin.rs
@@ -7,7 +7,11 @@ use crate::components::velocity::VelocityPlugin;
 use crate::fmod_studio::FmodStudio;
 
 pub struct FmodPlugin {
+    /// Paths to the audio banks which are usually in the Build folder of the FMOD project.
     pub audio_banks_paths: &'static [&'static str],
+
+    /// Optionally you can provide paths to FMOD plugins which will then be loaded automatically.
+    /// For more information see: https://www.fmod.com/docs/2.01/api/core-guide.html#dynamic
     pub plugin_paths: Option<&'static [&'static str]>,
 }
 
@@ -33,9 +37,9 @@ impl FmodPlugin {
         Ok(())
     }
 
-    pub fn from_audio_banks(paths: &'static [&'static str]) -> Self {
+    pub fn new(audio_banks_paths: &'static [&'static str]) -> Self {
         FmodPlugin {
-            audio_banks_paths: paths,
+            audio_banks_paths,
             plugin_paths: None,
         }
     }

--- a/src/fmod_plugin.rs
+++ b/src/fmod_plugin.rs
@@ -8,7 +8,7 @@ use crate::fmod_studio::FmodStudio;
 
 pub struct FmodPlugin {
     pub audio_banks_paths: &'static [&'static str],
-    pub plugin_paths: &'static [&'static str],
+    pub plugin_paths: Option<&'static [&'static str]>,
 }
 
 impl Plugin for FmodPlugin {
@@ -36,17 +36,7 @@ impl FmodPlugin {
     pub fn from_audio_banks(paths: &'static [&'static str]) -> Self {
         FmodPlugin {
             audio_banks_paths: paths,
-            plugin_paths: &[],
-        }
-    }
-
-    pub fn from(
-        audio_banks_paths: &'static [&'static str],
-        plugin_paths: &'static [&'static str],
-    ) -> Self {
-        FmodPlugin {
-            audio_banks_paths,
-            plugin_paths,
+            plugin_paths: None,
         }
     }
 }

--- a/src/fmod_plugin.rs
+++ b/src/fmod_plugin.rs
@@ -8,12 +8,13 @@ use crate::fmod_studio::FmodStudio;
 
 pub struct FmodPlugin {
     pub audio_banks_paths: &'static [&'static str],
+    pub plugin_paths: &'static [&'static str],
 }
 
 impl Plugin for FmodPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(VelocityPlugin)
-            .insert_resource(FmodStudio::new(self.audio_banks_paths))
+            .insert_resource(FmodStudio::new(self.audio_banks_paths, self.plugin_paths))
             .add_systems(
                 Update,
                 (
@@ -30,5 +31,12 @@ impl FmodPlugin {
     fn update(studio: Res<FmodStudio>) -> anyhow::Result<()> {
         studio.0.update()?;
         Ok(())
+    }
+
+    pub fn from_audio_bank_paths(paths: &'static [&'static str]) -> Self {
+        FmodPlugin {
+            audio_banks_paths: paths,
+            plugin_paths: &[],
+        }
     }
 }

--- a/src/fmod_plugin.rs
+++ b/src/fmod_plugin.rs
@@ -39,4 +39,14 @@ impl FmodPlugin {
             plugin_paths: &[],
         }
     }
+
+    pub fn from(
+        audio_banks_paths: &'static [&'static str],
+        plugin_paths: &'static [&'static str],
+    ) -> Self {
+        FmodPlugin {
+            audio_banks_paths,
+            plugin_paths,
+        }
+    }
 }

--- a/src/fmod_studio.rs
+++ b/src/fmod_studio.rs
@@ -1,8 +1,7 @@
-use std::env::var;
 use std::fs::canonicalize;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use bevy::prelude::{debug, trace, Resource};
+use bevy::prelude::{debug, Resource};
 #[cfg(feature = "live-update")]
 use libfmod::ffi::FMOD_STUDIO_INIT_LIVEUPDATE;
 use libfmod::ffi::{
@@ -16,42 +15,21 @@ pub struct FmodStudio(pub Studio);
 impl FmodStudio {
     pub(crate) fn new(banks_paths: &[&'static str], plugin_paths: &[&'static str]) -> Self {
         let studio = Self::init_studio();
-        let project_root = var("CARGO_MANIFEST_DIR").unwrap();
-
         let studio_core = studio.get_core_system().unwrap();
 
         plugin_paths.iter().for_each(|plugin_path| {
-            let mut path = canonicalize(Path::new(plugin_path))
+            let path = canonicalize(Path::new(plugin_path))
                 .expect("Failed to canonicalize provided audio banks directory path.");
-
-            trace!("Canonicalized audio banks directory path: {:?}", path);
-
-            if path.is_relative() {
-                let relative_path = path;
-                path = PathBuf::new();
-                path.push(project_root.clone());
-                path.push(relative_path)
-            }
 
             debug!("Loading FMOD plugins from: {:?}", path);
             Self::load_plugin(studio_core, path.as_path());
         });
 
         banks_paths.iter().for_each(|bank_path| {
-            let mut path = canonicalize(Path::new(bank_path))
+            let path = canonicalize(Path::new(bank_path))
                 .expect("Failed to canonicalize provided audio banks directory path.");
 
-            trace!("Canonicalized audio banks directory path: {:?}", path);
-
-            if path.is_relative() {
-                let relative_path = path;
-                path = PathBuf::new();
-                path.push(project_root.clone());
-                path.push(relative_path)
-            }
-
             debug!("Loading audio banks from: {:?}", path);
-
             Self::load_bank(&studio, path.as_path());
         });
 

--- a/src/fmod_studio.rs
+++ b/src/fmod_studio.rs
@@ -13,17 +13,19 @@ use libfmod::{Studio, System};
 pub struct FmodStudio(pub Studio);
 
 impl FmodStudio {
-    pub(crate) fn new(banks_paths: &[&'static str], plugin_paths: &[&'static str]) -> Self {
+    pub(crate) fn new(banks_paths: &[&'static str], plugin_paths: Option<&[&'static str]>) -> Self {
         let studio = Self::init_studio();
         let studio_core = studio.get_core_system().unwrap();
 
-        plugin_paths.iter().for_each(|plugin_path| {
-            let path = canonicalize(Path::new(plugin_path))
-                .expect("Failed to canonicalize provided audio banks directory path.");
+        if let Some(plugin_paths) = plugin_paths {
+            plugin_paths.iter().for_each(|plugin_path| {
+                let path = canonicalize(Path::new(plugin_path))
+                    .expect("Failed to canonicalize provided audio banks directory path.");
 
-            debug!("Loading FMOD plugins from: {:?}", path);
-            Self::load_plugin(studio_core, path.as_path());
-        });
+                debug!("Loading FMOD plugins from: {:?}", path);
+                Self::load_plugin(studio_core, path.as_path());
+            });
+        }
 
         banks_paths.iter().for_each(|bank_path| {
             let path = canonicalize(Path::new(bank_path))

--- a/src/fmod_studio.rs
+++ b/src/fmod_studio.rs
@@ -8,15 +8,34 @@ use libfmod::ffi::FMOD_STUDIO_INIT_LIVEUPDATE;
 use libfmod::ffi::{
     FMOD_INIT_3D_RIGHTHANDED, FMOD_STUDIO_INIT_NORMAL, FMOD_STUDIO_LOAD_BANK_NORMAL,
 };
-use libfmod::Studio;
+use libfmod::{Studio, System};
 
 #[derive(Resource)]
 pub struct FmodStudio(pub Studio);
 
 impl FmodStudio {
-    pub(crate) fn new(banks_paths: &[&'static str]) -> Self {
+    pub(crate) fn new(banks_paths: &[&'static str], plugin_paths: &[&'static str]) -> Self {
         let studio = Self::init_studio();
         let project_root = var("CARGO_MANIFEST_DIR").unwrap();
+
+        let studio_core = studio.get_core_system().unwrap();
+
+        plugin_paths.iter().for_each(|plugin_path| {
+            let mut path = canonicalize(Path::new(plugin_path))
+                .expect("Failed to canonicalize provided audio banks directory path.");
+
+            trace!("Canonicalized audio banks directory path: {:?}", path);
+
+            if path.is_relative() {
+                let relative_path = path;
+                path = PathBuf::new();
+                path.push(project_root.clone());
+                path.push(relative_path)
+            }
+
+            debug!("Loading FMOD plugins from: {:?}", path);
+            Self::load_plugin(studio_core, path.as_path());
+        });
 
         banks_paths.iter().for_each(|bank_path| {
             let mut path = canonicalize(Path::new(bank_path))
@@ -37,6 +56,17 @@ impl FmodStudio {
         });
 
         FmodStudio(studio)
+    }
+
+    fn load_plugin(studio_core: System, plugin_path: &Path) {
+        studio_core
+            .load_plugin(
+                plugin_path
+                    .to_str()
+                    .expect("Failed to convert path to string"),
+                None,
+            )
+            .expect("Could not FMOD plugin.");
     }
 
     fn load_bank(studio: &Studio, bank_path: &Path) {


### PR DESCRIPTION
Support FMOD [dynamic plugin loading](https://www.fmod.com/docs/2.01/api/core-guide.html#dynamic) by giving the user the option to provide paths to the plugins to be loaded.

Tested with my Steam Audio experiments, in which case it looks a bit like:
```rust
        .add_plugins((
            DefaultPlugins,
            PhononPlugin,
            FmodPlugin::from(
                &[
                    "./assets/audio/demo_project/Build/Desktop/Master.bank",
                    "./assets/audio/demo_project/Build/Desktop/Master.strings.bank",
                    "./assets/audio/demo_project/Build/Desktop/Music.bank",
                ],
                &["./phonon_fmod.dll"],
            ),
        ))
```

Also reduces indentation level in the examples.