### PR TITLE
Remove dependency on bevy_audio feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,18 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
-bevy = { version = "0.14", default-features = false, features = ["bevy_audio"] }
+bevy = { version = "0.14", default-features = false }
 bevy_mod_sysfail = "3.0"
 libfmod = "~2.206.2"
 
-[dev-dependencies]
-# The examples need the default features of bevy
-bevy = { version = "0.14", default-features = true }
+[dev-dependencies.bevy]
+version = "0.14"
+features = [
+    "bevy_core_pipeline",
+    "bevy_render",
+    "bevy_winit",
+    "multi_threaded"
+]
 
 [features]
 default = []

--- a/src/components/audio_source.rs
+++ b/src/components/audio_source.rs
@@ -1,5 +1,5 @@
 use bevy::math::Vec3;
-use bevy::prelude::{AudioSinkPlayback, Component, GlobalTransform, Query};
+use bevy::prelude::{Component, GlobalTransform, Query};
 use libfmod::StopMode::Immediate;
 use libfmod::{EventDescription, EventInstance, StopMode};
 
@@ -44,24 +44,24 @@ impl AudioSource {
     }
 }
 
-impl AudioSinkPlayback for AudioSource {
-    fn volume(&self) -> f32 {
+impl AudioSource {
+    pub fn volume(&self) -> f32 {
         self.event_instance.get_volume().unwrap().0
     }
 
-    fn set_volume(&self, volume: f32) {
+    pub fn set_volume(&self, volume: f32) {
         self.event_instance.set_volume(volume).unwrap();
     }
 
-    fn speed(&self) -> f32 {
+    pub fn speed(&self) -> f32 {
         self.event_instance.get_pitch().unwrap().0
     }
 
-    fn set_speed(&self, speed: f32) {
+    pub fn set_speed(&self, speed: f32) {
         self.event_instance.set_pitch(speed).unwrap();
     }
 
-    fn play(&self) {
+    pub fn play(&self) {
         if self.event_instance.get_paused().unwrap() {
             self.event_instance.set_paused(false).unwrap();
         } else {
@@ -69,20 +69,28 @@ impl AudioSinkPlayback for AudioSource {
         }
     }
 
-    fn pause(&self) {
+    pub fn pause(&self) {
         self.event_instance.set_paused(true).unwrap();
     }
 
-    fn is_paused(&self) -> bool {
+    pub fn is_paused(&self) -> bool {
         self.event_instance.get_paused().unwrap()
     }
 
-    fn stop(&self) {
+    pub fn stop(&self) {
         self.event_instance.stop(StopMode::AllowFadeout).unwrap();
     }
 
-    fn empty(&self) -> bool {
+    pub fn empty(&self) -> bool {
         self.event_instance.is_valid()
+    }
+
+    pub fn toggle(&self) {
+        if self.is_paused() {
+            self.play();
+        } else {
+            self.pause();
+        }
     }
 }
 


### PR DESCRIPTION
We previously included the `bevy_audio` feature to access the AudioSinkPlayback trait. I don't know anymore why I did that. I have no use case and no-one else has voiced a use case. I guess my intention was compatibility, but when using FMOD, my guess is that most users replace their entire audio solution anyways. 

In case we need some sort of compatibility, we should find a different solution in the future, i.e. an adapter between `bevy_fmod` and `bevy_audio` but as a separate struct.


This had the side effect, that in a project that doesn't use the `bevy_audio` feature, it still was implicitly introduced, and its structs exposed by `bevy::prelude:*`. 

As `bevy_fmod` uses some names for its structs that are also present in `bevy_audio`. This creates a name clash that can currently only be resolved with explicit import or import aliasing.

Closes #85  