### PR TITLE
Re-export libfmod and update to 2.222.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bevy = { version = "0.14", default-features = false }
-libfmod = "2.222.3"
+libfmod = "~2.222.5"
 
 [dev-dependencies.bevy]
 version = "0.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,6 @@ pub mod prelude;
 pub use fmod_plugin::FmodPlugin;
 #[doc(inline)]
 pub use fmod_studio::FmodStudio;
+
+// Re-export libfmod for plugin authors:
+pub use libfmod;


### PR DESCRIPTION
The 2.222.5 update of libfmod fixes some safety issues that were affecting FMOD plugins made using libfmod.

Re-exporting libfmod means plugin authors don't have to depend on both bevy_fmod and libfmod, and needing to keep the libfmod version in sync with that of bevy_fmod.