### PR TITLE
Add MuteWhenUnfocused utility plugin

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,7 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0" is_locked="false">
     <option name="myName" value="Project Default" />
-    <option name="myName" value="Project Default" />
     <inspection_tool class="RsAssociatedTypeMismatch" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ name = "spatial"
 name = "parameters"
 
 [features]
-default = []
+default = ["utilities"]
 live-update = []
+utilities = ["bevy/bevy_window"]
 
 [package]
 categories = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod fmod_plugin;
 #[doc(hidden)]
 pub mod fmod_studio;
 pub mod prelude;
+#[cfg(feature = "utilities")]
+pub mod utilities;
 
 #[doc(inline)]
 pub use fmod_plugin::FmodPlugin;

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -1,0 +1,9 @@
+//! # Utilities
+//!
+//! Collection of useful plugins, components or systems that are not part of the FMOD API but help
+//! when developing bevy games with FMOD.
+
+mod mute_when_unfocused;
+
+#[doc(inline)]
+pub use mute_when_unfocused::MuteWhenUnfocused;

--- a/src/utilities/mute_when_unfocused.rs
+++ b/src/utilities/mute_when_unfocused.rs
@@ -1,0 +1,31 @@
+use crate::FmodStudio;
+use bevy::app::{App, Plugin, Update};
+use bevy::ecs::error::Result;
+use bevy::prelude::{Entity, Local, MessageReader, ResMut, Single, With};
+use bevy::window::{PrimaryWindow, WindowFocused};
+
+/// When this plugin is added, the audio will be muted when the [PrimaryWindow] is not focused
+/// and vice versa.
+pub struct MuteWhenUnfocused;
+
+impl Plugin for MuteWhenUnfocused {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, mute_when_unfocused);
+    }
+}
+
+fn mute_when_unfocused(
+    mut focus_event: MessageReader<WindowFocused>,
+    primary_window: Single<Entity, With<PrimaryWindow>>,
+    mut last_focus_state: Local<bool>,
+    studio: ResMut<FmodStudio>,
+) -> Result {
+    for WindowFocused { window, focused } in focus_event.read() {
+        if *window == *primary_window && *last_focus_state != *focused {
+            studio.get_bus("bus:/")?.set_mute(!focused)?;
+            *last_focus_state = *focused;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
- New utilities module added
 MuteWhenUnfocused plugin implemented
- Plugin listens for WindowFocused events
- Compares events to PrimaryWindow and tracks-focus state
- Toggles FMOD master bus ("bus:/") mute when focus changes